### PR TITLE
Add basic Express server with Socket.IO

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+
+// Serve static files from public directory
+app.use(express.static('public'));
+
+// Attach Socket.IO with no CORS restrictions for development
+const io = new Server(server, {
+  cors: {
+    origin: '*',
+  },
+});
+
+server.listen(3000, () => {
+  console.log('Server listening on port 3000');
+});
+
+module.exports = io;


### PR DESCRIPTION
## Summary
- create `server.js` with Express and Socket.IO
- serve static files from `public/`
- export the Socket.IO instance for tests

## Testing
- `npm install`
- `node server.js` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_b_68409f8fc1248324bb1b8749721bad65