### PR TITLE
Add browser game scenes

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -1,0 +1,56 @@
+class Lobby extends Phaser.Scene {
+  constructor() {
+    super('Lobby');
+  }
+
+  create() {
+    const form = document.createElement('form');
+
+    const nickInput = document.createElement('input');
+    nickInput.name = 'nick';
+    nickInput.placeholder = 'Nickname';
+
+    const roomInput = document.createElement('input');
+    roomInput.name = 'room';
+    roomInput.placeholder = 'Room';
+
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.textContent = 'Join';
+
+    form.appendChild(nickInput);
+    form.appendChild(roomInput);
+    form.appendChild(submit);
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const nick = nickInput.value.trim();
+      const roomId = roomInput.value.trim();
+      socket.emit('join', { roomId, nick });
+      form.remove();
+      this.scene.start('Play');
+    });
+
+    document.body.appendChild(form);
+  }
+}
+
+class Play extends Phaser.Scene {
+  constructor() {
+    super('Play');
+  }
+
+  create() {
+    this.add.text(100, 100, 'Waiting for game...', { fontSize: '32px', fill: '#fff' });
+  }
+}
+
+class End extends Phaser.Scene {
+  constructor() {
+    super('End');
+  }
+}
+
+const socket = io();
+const config = { type: Phaser.AUTO, width: 800, height: 600, scene: [Lobby, Play, End] };
+new Phaser.Game(config);


### PR DESCRIPTION
## Summary
- add Lobby/Play/End Phaser scenes for a simple Socket.IO game
- wire up new scenes in `public/game.js`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6840a76a44388324895e438cbd01f6d8