### PR TITLE
Implement ladder visuals and climb animation

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -40,8 +40,43 @@ class Play extends Phaser.Scene {
     super('Play');
   }
 
+  preload() {
+    this.load.image('ladder', 'ladder.png');
+    this.load.image('brick-bg', 'brick-bg.png');
+    const colors = ['red', 'orange', 'yellow', 'green', 'blue'];
+    for (const c of colors) {
+      this.load.image(`avatar-${c}`, `avatar-${c}.png`);
+    }
+  }
+
   create() {
     this.add.text(100, 100, 'Waiting for game...', { fontSize: '32px', fill: '#fff' });
+    socket.on('snapshot', (state) => this.drawState(state));
+    socket.on('climb', ({ teamId, rung }) => {
+      const sprite = this.avatarSprites && this.avatarSprites[teamId];
+      if (sprite) {
+        this.tweens.add({ targets: sprite, y: this.yForRung(rung), duration: 300 });
+      }
+    });
+  }
+
+  yForRung(r) {
+    return 530 - r * 40;
+  }
+
+  drawState(snapshot) {
+    this.add.image(400, 300, 'brick-bg');
+    this.avatarSprites = [];
+    for (let i = 0; i < ladderX.length; i++) {
+      this.add.image(ladderX[i], 300, 'ladder');
+    }
+
+    const colors = ['red', 'orange', 'yellow', 'green', 'blue'];
+    for (let i = 0; i < snapshot.teams.length; i++) {
+      const team = snapshot.teams[i];
+      const sprite = this.add.sprite(ladderX[i], this.yForRung(team.rung || 0), `avatar-${colors[i]}`);
+      this.avatarSprites[i] = sprite;
+    }
   }
 }
 
@@ -52,5 +87,6 @@ class End extends Phaser.Scene {
 }
 
 const socket = io();
+const ladderX = [100, 260, 420, 580, 740];
 const config = { type: Phaser.AUTO, width: 800, height: 600, scene: [Lobby, Play, End] };
 new Phaser.Game(config);


### PR DESCRIPTION
## Summary
- preload ladder, brick background, and avatars in Play scene
- position ladders with `ladderX` constant
- draw ladders and avatars from server snapshot
- animate avatar climbing with tween when receiving `climb` event
- add rung-to-y position helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840a96a65748324ad43a5d99e666292