### PR TITLE
Handle questions in Play scene

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -27,6 +27,7 @@ class Lobby extends Phaser.Scene {
       const nick = nickInput.value.trim();
       const roomId = roomInput.value.trim();
       socket.emit('join', { roomId, nick });
+      socket.roomId = roomId;
       form.remove();
       this.scene.start('Play');
     });
@@ -51,11 +52,19 @@ class Play extends Phaser.Scene {
 
   create() {
     this.add.text(100, 100, 'Waiting for game...', { fontSize: '32px', fill: '#fff' });
+    this.createAnswerUi();
     socket.on('snapshot', (state) => this.drawState(state));
     socket.on('climb', ({ teamId, rung }) => {
       const sprite = this.avatarSprites && this.avatarSprites[teamId];
       if (sprite) {
         this.tweens.add({ targets: sprite, y: this.yForRung(rung), duration: 300 });
+        this.flashSprite(teamId, 0x00ff00);
+      }
+    });
+    socket.on('question', (q) => this.showQuestion(q));
+    socket.on('answerWrong', () => {
+      if (this.myTeamId !== undefined) {
+        this.flashSprite(this.myTeamId, 0xff0000);
       }
     });
   }
@@ -76,7 +85,101 @@ class Play extends Phaser.Scene {
       const team = snapshot.teams[i];
       const sprite = this.add.sprite(ladderX[i], this.yForRung(team.rung || 0), `avatar-${colors[i]}`);
       this.avatarSprites[i] = sprite;
+      if (team.players.some(p => p.id === socket.id)) {
+        this.myTeamId = team.id !== undefined ? team.id : i;
+      }
     }
+  }
+
+  createAnswerUi() {
+    const container = document.createElement('div');
+    container.style.position = 'absolute';
+    container.style.bottom = '10px';
+    container.style.left = '50%';
+    container.style.transform = 'translateX(-50%)';
+    container.style.background = 'rgba(0,0,0,0.5)';
+    container.style.padding = '10px';
+    container.style.color = '#fff';
+    container.style.display = 'none';
+
+    const questionEl = document.createElement('div');
+    container.appendChild(questionEl);
+
+    const optionsEl = document.createElement('div');
+    container.appendChild(optionsEl);
+
+    const timerEl = document.createElement('div');
+    timerEl.style.marginTop = '4px';
+    container.appendChild(timerEl);
+
+    const submit = document.createElement('button');
+    submit.textContent = 'Submit';
+    submit.style.display = 'block';
+    submit.style.marginTop = '4px';
+    container.appendChild(submit);
+
+    submit.addEventListener('click', () => this.submitAnswer());
+
+    document.body.appendChild(container);
+
+    this.qContainer = container;
+    this.qQuestionEl = questionEl;
+    this.qOptionsEl = optionsEl;
+    this.qTimerEl = timerEl;
+  }
+
+  showQuestion(q) {
+    this.currentQ = q;
+    this.qQuestionEl.textContent = q.prompt;
+    this.qOptionsEl.innerHTML = '';
+    q.options.forEach(opt => {
+      const label = document.createElement('label');
+      label.style.display = 'block';
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'answer';
+      input.value = opt;
+      label.appendChild(input);
+      label.appendChild(document.createTextNode(opt));
+      this.qOptionsEl.appendChild(label);
+    });
+    this.qContainer.style.display = 'block';
+    this.startCountdown(q.timeMs || 15000);
+  }
+
+  startCountdown(ms) {
+    if (this.timerEvent) this.timerEvent.remove();
+    let remaining = Math.ceil(ms / 1000);
+    this.qTimerEl.textContent = `Time: ${remaining}`;
+    this.timerEvent = this.time.addEvent({
+      delay: 1000,
+      repeat: remaining - 1,
+      callback: () => {
+        remaining -= 1;
+        this.qTimerEl.textContent = `Time: ${remaining}`;
+        if (remaining <= 0) {
+          this.timerEvent = null;
+        }
+      }
+    });
+  }
+
+  submitAnswer() {
+    if (!this.currentQ) return;
+    const checked = this.qOptionsEl.querySelector('input[name="answer"]:checked');
+    const answer = checked ? checked.value : '';
+    socket.emit('answer', { roomId: socket.roomId, id: this.currentQ.id, answer });
+    this.qContainer.style.display = 'none';
+    this.currentQ = null;
+  }
+
+  flashSprite(teamId, color) {
+    const sprite = this.avatarSprites && this.avatarSprites[teamId];
+    if (!sprite) return;
+    const g = this.add.graphics();
+    g.lineStyle(4, color, 1);
+    g.strokeRect(sprite.x - sprite.width / 2 - 4, sprite.y - sprite.height / 2 - 4, sprite.width + 8, sprite.height + 8);
+    this.time.delayedCall(200, () => g.destroy());
   }
 }
 


### PR DESCRIPTION
## Summary
- store roomId on join
- build question UI in the Play scene
- emit answers and show countdown timer
- highlight ladder sprites for correct/wrong answers

## Testing
- `npm install`
- `npm start` *(server starts on port 3000)*

------
https://chatgpt.com/codex/tasks/task_b_6840aa60192c8324ae2587f88a464208