### PR TITLE
Implement team cleanup and auto join

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -28,6 +28,9 @@ class Lobby extends Phaser.Scene {
       const roomId = roomInput.value.trim();
       socket.emit('join', { roomId, nick });
       socket.roomId = roomId;
+      try {
+        localStorage.setItem('session', JSON.stringify({ roomId, nick }));
+      } catch (err) {}
       form.remove();
       this.scene.start('Play');
     });
@@ -198,3 +201,14 @@ const socket = io();
 const ladderX = [100, 260, 420, 580, 740];
 const config = { type: Phaser.AUTO, width: 800, height: 600, scene: [Lobby, Play, End] };
 new Phaser.Game(config);
+
+try {
+  const saved = localStorage.getItem('session');
+  if (saved) {
+    const { roomId, nick } = JSON.parse(saved);
+    if (roomId && nick) {
+      socket.emit('join', { roomId, nick });
+      socket.roomId = roomId;
+    }
+  }
+} catch (err) {}


### PR DESCRIPTION
## Summary
- remove disconnected player and cleanup empty teams/rooms
- persist room and nick in localStorage and auto-join when page loads

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840abd9b4108324bdd122c051b5e029