### PR TITLE
Fix join crash from unsanitized room data

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,6 +56,27 @@ function startQuestionLoop(roomId) {
   }, 15000);
 }
 
+function createRoomSnapshot(room) {
+  const snapshot = {
+    phase: room.phase,
+    ladderHeight: room.ladderHeight,
+    qIndex: room.qIndex,
+    teams: room.teams.map(t => ({
+      id: t.id,
+      rung: t.rung,
+      players: t.players,
+    })),
+  };
+  if (room.currentQuestion) {
+    snapshot.currentQuestion = {
+      id: room.currentQuestion.id,
+      prompt: room.currentQuestion.prompt,
+      options: room.currentQuestion.options,
+    };
+  }
+  return snapshot;
+}
+
 // Serve static files from public directory
 app.use(express.static('public'));
 
@@ -72,7 +93,7 @@ io.on('connection', (socket) => {
     const { team, player } = assignToSmallestTeam(room, nick, socket.id);
     socket.join(roomId);
     socket.roomId = roomId;
-    socket.emit('snapshot', room);
+    socket.emit('snapshot', createRoomSnapshot(room));
     io.to(roomId).emit('playerJoined', { roomId, team, player });
     startQuestionLoop(roomId);
   });


### PR DESCRIPTION
## Summary
- filter room state before emitting snapshot to client

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841e765a4d48324a39ee6794cf6b87d