### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clone the repository and install packages:
 
 ```bash
 git clone <repo-url>
-cd ladder-run
+cd ladder_run
 npm install
 ```
 


### PR DESCRIPTION
## Summary
- fix README to use `cd ladder_run` in the setup instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841ecec55448324b234d6f9c5a55aa2