### PR TITLE
Allow PORT override for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Launch the app in development mode using **nodemon**:
 npm run dev
 ```
 
-The server runs on `http://localhost:3000`. Open this URL in your browser to start playing.
+The server runs on `http://localhost:3000` by default. You can override the port by setting the `PORT` environment variable.

--- a/server.js
+++ b/server.js
@@ -161,8 +161,8 @@ io.on('connection', (socket) => {
   });
 });
 
-server.listen(3000, () => {
-  console.log('Server listening on port 3000');
+server.listen(process.env.PORT || 3000, () => {
+  console.log(`Server listening on port ${process.env.PORT || 3000}`);
 });
 
 module.exports = io;


### PR DESCRIPTION
## Summary
- make `server.js` respect the `PORT` environment variable
- document port override in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841ecf67c608324ba4fbe50e0389e41